### PR TITLE
Add LoRa-E5 radio board config

### DIFF
--- a/Seeed-LoRa-E5_PingPong/Core/Inc/platform.h
+++ b/Seeed-LoRa-E5_PingPong/Core/Inc/platform.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* Exported constants --------------------------------------------------------*/
 
-#define USE_BSP_DRIVER
+#undef USE_BSP_DRIVER
 /* USER CODE BEGIN EC */
 
 /* USER CODE END EC */

--- a/Seeed-LoRa-E5_PingPong/SubGHz_Phy/Target/radio_board_if.h
+++ b/Seeed-LoRa-E5_PingPong/SubGHz_Phy/Target/radio_board_if.h
@@ -63,7 +63,7 @@ extern "C" {
 /* USER CODE END Exported Parameters */
 /* Indicates the type of switch between the ones proposed by CONFIG Constants
  */
-#define RBI_CONF_RFO                        RBI_CONF_RFO_LP_HP
+#define RBI_CONF_RFO                        RBI_CONF_RFO_HP
 
 /* Indicates whether or not TCXO is supported by the board
  * 0: TCXO not supported
@@ -75,7 +75,7 @@ extern "C" {
  * 0: DCDC not supported
  * 1: DCDC supported
  */
-#define IS_DCDC_SUPPORTED                   1U
+#define IS_DCDC_SUPPORTED                   0U
 
 /* USER CODE BEGIN Exported Parameters_2 */
 
@@ -89,7 +89,20 @@ extern "C" {
 
 #else
 /* USER CODE BEGIN Exported PinMapping */
-#warning user to provide its board definitions pins
+#define RF_SW_CTRL1_PIN                          RF_CTRL1_Pin
+#define RF_SW_CTRL1_GPIO_PORT                    RF_CTRL1_GPIO_Port
+#define RF_SW_CTRL1_GPIO_CLK_ENABLE()            __HAL_RCC_GPIOA_CLK_ENABLE()
+#define RF_SW_CTRL1_GPIO_CLK_DISABLE()           __HAL_RCC_GPIOA_CLK_DISABLE()
+
+#define RF_SW_CTRL2_PIN                          RF_CTRL2_Pin
+#define RF_SW_CTRL2_GPIO_PORT                    RF_CTRL2_GPIO_Port
+#define RF_SW_CTRL2_GPIO_CLK_ENABLE()            __HAL_RCC_GPIOA_CLK_ENABLE()
+#define RF_SW_CTRL2_GPIO_CLK_DISABLE()           __HAL_RCC_GPIOA_CLK_DISABLE()
+
+#define RF_TCXO_VCC_PIN                          GPIO_PIN_0
+#define RF_TCXO_VCC_GPIO_PORT                    GPIOB
+#define RF_TCXO_VCC_CLK_ENABLE()                 __HAL_RCC_GPIOB_CLK_ENABLE()
+#define RF_TCXO_VCC_CLK_DISABLE()                __HAL_RCC_GPIOB_CLK_DISABLE()
 /* USER CODE END Exported PinMapping */
 #endif  /* USE_BSP_DRIVER  */
 


### PR DESCRIPTION
## Summary
- disable BSP implementation and supply board specific radio pins
- provide LoRa-E5 pin mapping and features in `radio_board_if.h`
- implement GPIO based RF switch control and board settings in `radio_board_if.c`

## Testing
- `arm-none-eabi-gcc -c Seeed-LoRa-E5_PingPong/SubGHz_Phy/Target/radio_board_if.c -ISeeed-LoRa-E5_PingPong/Core/Inc -ISeeed-LoRa-E5_PingPong/SubGHz_Phy/Target -ISeeed-LoRa-E5_PingPong/Drivers/STM32WLxx_HAL_Driver/Inc -ISeeed-LoRa-E5_PingPong/Drivers/CMSIS/Device/ST/STM32WLxx/Include -ISeeed-LoRa-E5_PingPong/Drivers/CMSIS/Include -ISeeed-LoRa-E5_PingPong/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver -mcpu=cortex-m4 -mthumb` *(fails: unknown type name `uint16_t`)*

------
https://chatgpt.com/codex/tasks/task_e_6884c6d6ad508324b55c9bbfeaa9bb66